### PR TITLE
feature: add missing view_plant_export_energy_monthly to dbt models

### DIFF
--- a/dbt_jardiner/dbt_project.yml
+++ b/dbt_jardiner/dbt_project.yml
@@ -36,3 +36,5 @@ models:
     # Config indicated by + and applies to all files under models/example/
     operational:
       +materialized: view
+      +grants:
+        select: 'opendata'

--- a/dbt_jardiner/models/operational/derived/view_plant_export_energy_monthly.sql
+++ b/dbt_jardiner/models/operational/derived/view_plant_export_energy_monthly.sql
@@ -1,0 +1,12 @@
+{{ config(materialized='view') }}
+
+select
+    date_trunc('month', (time - interval '1 hour') at time zone 'Europe/Madrid') as time,
+    meter.plant as plant_id,
+    meter as meter_id,
+    sum(export_energy_wh) as export_energy_wh,
+    sum(import_energy_wh) as import_energy_wh
+from {{ source('plantmonitordb','meterregistry') }} as mr
+left join {{ source('plantmonitordb','meter') }} on meter.id = mr.meter
+left join {{ source('plantmonitordb','plant') }} as plant on plant.id = meter.plant
+group by time, plant_id, meter_id


### PR DESCRIPTION
adds a new dbt model needed for query at https://github.com/Som-Energia/somenergia-opendata/blob/master/som_opendata/queries/plantproduction.sql

References helpscout issue at

https://secure.helpscout.net/conversation/2282337307/15102454?folderId=7395678