### PR TITLE
fix: update dbt model with better date_trunc usage

### DIFF
--- a/dbt_jardiner/models/operational/derived/view_plant_export_energy_monthly.sql
+++ b/dbt_jardiner/models/operational/derived/view_plant_export_energy_monthly.sql
@@ -1,7 +1,7 @@
 {{ config(materialized='view') }}
 
 SELECT
-	date_trunc('month', meterregistry."time") AS "time",
+	date_trunc('month', (meterregistry."time" - interval '1 hour'), 'Europe/Madrid') as "time",
 	plant.id AS plant_id,
 	plant.name AS plant_name,
 	meter.id AS meter_id,
@@ -18,6 +18,6 @@ LEFT JOIN
 ON 
 	meter.id = meterregistry.meter
 GROUP BY 
-	date_trunc('month', meterregistry."time"), plant_id, plant_name, meter_id, meter_name
+	date_trunc('month', (meterregistry."time" - interval '1 hour'), 'Europe/Madrid'), plant_id, plant_name, meter_id, meter_name
 ORDER BY 
-	date_trunc('month', meterregistry."time"), plant_id, plant_name, meter_id, meter_name
+	date_trunc('month', (meterregistry."time" - interval '1 hour'), 'Europe/Madrid'), plant_id, plant_name, meter_id, meter_name


### PR DESCRIPTION
## Description

Updates dbt model with better time handling

## Changes

- dates are now aligned to the beginning of their periods using interval shifts
- resulting month from `date_trunc` uses `Europe/Madrid` timezone

## Observations

This continues on the work done at #1.

